### PR TITLE
Preserve Request Parameters and Authentication Tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ Provides deterministic / bookmarkable URLs which the [CircleCI REST API](https:/
 
 The URLs below respond with a HTTP 302 redirect to a specific build on circleci, so whenever you use this API ensure that your HTTP client follows redirects.
 
+## Public Instance
+
+A public instance of circleci-redirector is running here:
+
+ * [https://circleciredirector-tkn.rhcloud.com/](https://circleciredirector-tkn.rhcloud.com/)
+
+It currently runs on [OpenShift](https://www.openshift.com/pricing/plan-comparison.html), and is auto-deployed whenever something is committed to `master`. I plan to keep it running there, as it really does not incur any costs. Feel free to use it as is, or fork this repo and deploy it on your own if you want more control.
+
 ## URL Patterns
 
 Get redirected to the latest build details:
@@ -21,6 +29,17 @@ Get redirected to the list of build artifacts for the latest build:
 Get redirected to the download link of a specific build artifact:
 
  * `GET /api/v1/<user>/<project>/tree/<branch>/latest/artifacts/<artifact>`
+
+## Request Parameters / Authentication Tokens
+
+All request parameters are preserved when redirecting to the CircleCI API, which also includes the authentication tokens (`circle-token=1234...`) which the [CircleCI REST API](https://circleci.com/docs/api) uses.
+
+
+Whenever you need to transmit sensitive data such as authentication tokens, please:
+
+ * use https only
+ * consider using per-project auth tokens with limited access
+ * consider running your own circleci-redirector
 
 ## Development
 

--- a/app.rb
+++ b/app.rb
@@ -14,13 +14,13 @@ end
 
 get '/api/v1/:user/:project/tree/:branch/latest' do |user, project, branch|
   latest = latest_build(user, project, branch)
-  redirect to(build_details(user, project, latest['build_num']))
+  redirect_to build_details(user, project, latest['build_num'])
 end
 
 get '/api/v1/:user/:project/tree/:branch/latest/artifacts' do |user, project, branch|
   latest = latest_build(user, project, branch)
   if (latest['has_artifacts'] == true)
-    redirect to(build_artifacts(user, project, latest['build_num']))
+    redirect_to build_artifacts(user, project, latest['build_num'])
   else
     not_found 'no artifacts for this build'
   end
@@ -31,7 +31,7 @@ get '/api/v1/:user/:project/tree/:branch/latest/artifacts/:artifact' do |user, p
   if (latest['has_artifacts'] == true)
     found_artifact = find_artifact(user, project, latest['build_num'], artifact)
     if found_artifact
-      redirect to(found_artifact['url'])
+      redirect_to found_artifact['url']
     else
       not_found 'no such artifact'
     end
@@ -42,6 +42,13 @@ end
 
 def not_found(message)
   [404, {'Content-Type' => 'text/plain'}, message]
+end
+
+def redirect_to(url)
+  unless request.query_string.empty?
+    url << '?' << request.query_string
+  end
+  redirect to(url)
 end
 
 def latest_build(user, project, branch)

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,3 @@
+RewriteEngine on
+RewriteCond %{HTTP:X-Forwarded-Proto} !https
+RewriteRule .* https://%{HTTP_HOST}%{REQUEST_URI} [R,L]


### PR DESCRIPTION
This PR:
- preserves request parameters as-is when redirecting to circleci
- enforces https when using the public instance on OpenShift
- adds README documentation on the public instance and request parameter handling
