### PR TITLE
Catch all /api/v1 requests so we can act as a drop-in replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ Get redirected to the latest build on a specific branch:
 
  * `GET /api/v1/project/<user>/<project>/tree/<branch>/latest`
 
-Get redirected to the list of build artifacts for the latest build:
+Get redirected to the test results for the latest build on a specific branch:
+
+ * `GET /api/v1/project/<user>/<project>/tree/<branch>/latest/tests`
+
+Get redirected to the list of build artifacts for the latest build on a specific branch:
 
  * `GET /api/v1/project/<user>/<project>/tree/<branch>/latest/artifacts`
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 
 # CircleCI Redirector
 
-Provides deterministic / bookmarkable URLs which the [CircleCI REST API](https://circleci.com/docs/api) currently does not offer:
+Extends the [CircleCI REST API](https://circleci.com/docs/api) with deterministic / bookmarkable URLs for:
 
- * link to latest build on a specific branch
- * deterministic URLs for build artifacts
+ * latest build on a specific branch
+ * build artifact download links
 
-The URLs below respond with a HTTP 302 redirect to a specific build on circleci, so whenever you use this API ensure that your HTTP client follows redirects.
+The circleci-redirector acts as a drop-in replacement for all GET requests to the CircleCI REST API. It adds a few new URL patterns (see below), but still supports the old ones.
+
+Note that every request is responded with a HTTP 302 redirect to a specific build on CircleCI, so whenever you use this API ensure that your HTTP client follows redirects.
 
 ## Public Instance
 
@@ -14,9 +16,11 @@ A public instance of circleci-redirector is running here:
 
  * [https://circleciredirector-tkn.rhcloud.com/](https://circleciredirector-tkn.rhcloud.com/)
 
-It currently runs on [OpenShift](https://www.openshift.com/pricing/plan-comparison.html), and is auto-deployed whenever something is committed to `master`. I plan to keep it running there, as it really does not incur any costs. Feel free to use it as is, or fork this repo and deploy it on your own if you want more control.
+It is being auto-deployed whenever something is committed to `master`. Feel free to use it as-is, or fork this repo and deploy it on your own if you want more control.
 
 ## URL Patterns
+
+### New API Endpoints
 
 Get redirected to the latest build on a specific branch:
 
@@ -33,6 +37,12 @@ Get redirected to the list of build artifacts for the latest build on a specific
 Get redirected to the download link of a specific build artifact:
 
  * `GET /api/v1/project/<user>/<project>/tree/<branch>/latest/artifacts/<artifact>`
+
+### Existing API Endpoints
+
+Every other GET request to `/api/v1/*` which does not match the above patterns is being HTTP 302 redirected to the [CircleCI REST API](https://circleci.com/docs/api) as-is, which means you can use it as a drop-in replacement if you want.
+
+POST and DELETE requests are currently not forwarded or redirected.
 
 ## Request Parameters / Authentication Tokens
 

--- a/README.md
+++ b/README.md
@@ -18,17 +18,17 @@ It currently runs on [OpenShift](https://www.openshift.com/pricing/plan-comparis
 
 ## URL Patterns
 
-Get redirected to the latest build details:
+Get redirected to the latest build on a specific branch:
 
- * `GET /api/v1/<user>/<project>/tree/<branch>/latest`
+ * `GET /api/v1/project/<user>/<project>/tree/<branch>/latest`
 
 Get redirected to the list of build artifacts for the latest build:
 
- * `GET /api/v1/<user>/<project>/tree/<branch>/latest/artifacts`
+ * `GET /api/v1/project/<user>/<project>/tree/<branch>/latest/artifacts`
 
 Get redirected to the download link of a specific build artifact:
 
- * `GET /api/v1/<user>/<project>/tree/<branch>/latest/artifacts/<artifact>`
+ * `GET /api/v1/project/<user>/<project>/tree/<branch>/latest/artifacts/<artifact>`
 
 ## Request Parameters / Authentication Tokens
 

--- a/app.rb
+++ b/app.rb
@@ -41,41 +41,49 @@ get '/api/v1/:user/:project/tree/:branch/latest/artifacts/:artifact' do |user, p
 end
 
 get '/api/v1/*' do |path|
-  redirect_to "https://circleci.com/api/v1/#{path}"
+  redirect_to circleci_api(path)
 end
 
-def not_found(message)
-  [404, {'Content-Type' => 'text/plain'}, message]
-end
 
-def redirect_to(url)
-  unless request.query_string.empty?
-    url << '?' << request.query_string
+helpers do
+
+  def not_found(message)
+    [404, {'Content-Type' => 'text/plain'}, message]
   end
-  redirect to(url)
-end
 
-def latest_build(user, project, branch)
-  JSON.parse(fetch(build_summaries(user, project, branch, 1))).first
-end
+  def redirect_to(url)
+    unless request.query_string.empty?
+      url << '?' << request.query_string
+    end
+    redirect to(url)
+  end
 
-def find_artifact(user, project, build_num, artifact_name)
-  artifacts = JSON.parse(fetch(build_artifacts(user, project, build_num)))
-  artifacts.find { |it| it['pretty_path'].end_with? artifact_name }
-end
+  def latest_build(user, project, branch)
+    JSON.parse(fetch(build_summaries(user, project, branch, 1))).first
+  end
 
-def build_summaries(user, project, branch, limit = 30)
-  "https://circleci.com/api/v1/project/#{user}/#{project}/tree/#{branch}?limit=#{limit}"
-end
+  def find_artifact(user, project, build_num, artifact_name)
+    artifacts = JSON.parse(fetch(build_artifacts(user, project, build_num)))
+    artifacts.find { |it| it['pretty_path'].end_with? artifact_name }
+  end
 
-def build_details(user, project, build_num)
-  "https://circleci.com/api/v1/project/#{user}/#{project}/#{build_num}"
-end
+  def circleci_api(path)
+    "https://circleci.com/api/v1/#{path}"
+  end
 
-def build_artifacts(user, project, build_num)
-  "https://circleci.com/api/v1/project/#{user}/#{project}/#{build_num}/artifacts"
-end
+  def build_summaries(user, project, branch, limit = 30)
+    circleci_api("project/#{user}/#{project}/tree/#{branch}?limit=#{limit}")
+  end
 
-def fetch(url)
-  open(url).read
+  def build_details(user, project, build_num)
+    circleci_api("project/#{user}/#{project}/#{build_num}")
+  end
+
+  def build_artifacts(user, project, build_num)
+    circleci_api("project/#{user}/#{project}/#{build_num}/artifacts")
+  end
+
+  def fetch(url)
+    open(url).read
+  end
 end

--- a/app.rb
+++ b/app.rb
@@ -19,11 +19,12 @@ end
 
 get '/api/v1/project/:user/:project/tree/:branch/latest/artifacts' do |user, project, branch|
   latest = latest_build(user, project, branch)
-  if (latest['has_artifacts'] == true)
-    redirect_to build_artifacts(user, project, latest['build_num'])
-  else
-    not_found 'no artifacts for this build'
-  end
+  redirect_to build_artifacts(user, project, latest['build_num'])
+end
+
+get '/api/v1/project/:user/:project/tree/:branch/latest/tests' do |user, project, branch|
+  latest = latest_build(user, project, branch)
+  redirect_to build_testresults(user, project, latest['build_num'])
 end
 
 get '/api/v1/project/:user/:project/tree/:branch/latest/artifacts/:artifact' do |user, project, branch, artifact|
@@ -81,6 +82,10 @@ helpers do
 
   def build_artifacts(user, project, build_num)
     circleci_api("project/#{user}/#{project}/#{build_num}/artifacts")
+  end
+
+  def build_testresults(user, project, build_num)
+    circleci_api("project/#{user}/#{project}/#{build_num}/tests")
   end
 
   def fetch(url)

--- a/app.rb
+++ b/app.rb
@@ -40,6 +40,10 @@ get '/api/v1/:user/:project/tree/:branch/latest/artifacts/:artifact' do |user, p
   end
 end
 
+get '/api/v1/*' do |path|
+  redirect_to "https://circleci.com/api/v1/#{path}"
+end
+
 def not_found(message)
   [404, {'Content-Type' => 'text/plain'}, message]
 end

--- a/app.rb
+++ b/app.rb
@@ -12,12 +12,12 @@ get '/' do
   markdown :index
 end
 
-get '/api/v1/:user/:project/tree/:branch/latest' do |user, project, branch|
+get '/api/v1/project/:user/:project/tree/:branch/latest' do |user, project, branch|
   latest = latest_build(user, project, branch)
   redirect_to build_details(user, project, latest['build_num'])
 end
 
-get '/api/v1/:user/:project/tree/:branch/latest/artifacts' do |user, project, branch|
+get '/api/v1/project/:user/:project/tree/:branch/latest/artifacts' do |user, project, branch|
   latest = latest_build(user, project, branch)
   if (latest['has_artifacts'] == true)
     redirect_to build_artifacts(user, project, latest['build_num'])
@@ -26,7 +26,7 @@ get '/api/v1/:user/:project/tree/:branch/latest/artifacts' do |user, project, br
   end
 end
 
-get '/api/v1/:user/:project/tree/:branch/latest/artifacts/:artifact' do |user, project, branch, artifact|
+get '/api/v1/project/:user/:project/tree/:branch/latest/artifacts/:artifact' do |user, project, branch, artifact|
   latest = latest_build(user, project, branch)
   if (latest['has_artifacts'] == true)
     found_artifact = find_artifact(user, project, latest['build_num'], artifact)

--- a/views/index.md
+++ b/views/index.md
@@ -2,6 +2,8 @@ Basic Usage
 
  * redirect to build details ([example](/api/v1/project/tknerr/linus-kitchen/tree/master/latest)):
   * `GET /api/v1/project/<user>/<project>/tree/<branch>/latest`
+ * redirect to test results ([example](/api/v1/project/tknerr/linus-kitchen/tree/master/latest/tests)):
+  * `GET /api/v1/project/<user>/<project>/tree/<branch>/latest/tests`
  * redirect to list of artifacts ([example](/api/v1/project/tknerr/linus-kitchen/tree/master/latest/artifacts)):
   * `GET /api/v1/project/<user>/<project>/tree/<branch>/latest/artifacts`
  * redirect to build artifact download ([example](/api/v1/project/tknerr/linus-kitchen/tree/master/latest/artifacts/test-report.html)):

--- a/views/index.md
+++ b/views/index.md
@@ -1,10 +1,10 @@
 Basic Usage
 
- * redirect to build details ([example](/api/v1/tknerr/linus-kitchen/tree/master/latest)):
-  * `GET /api/v1/<user>/<project>/tree/<branch>/latest`
- * redirect to list of artifacts ([example](/api/v1/tknerr/linus-kitchen/tree/master/latest/artifacts)):
-  * `GET /api/v1/<user>/<project>/tree/<branch>/latest/artifacts`
- * redirect to build artifact download ([example](/api/v1/tknerr/linus-kitchen/tree/master/latest/artifacts/test-report.html)):
-  * `GET /api/v1/<user>/<project>/tree/<branch>/latest/artifacts/<artifact>`
+ * redirect to build details ([example](/api/v1/project/tknerr/linus-kitchen/tree/master/latest)):
+  * `GET /api/v1/project/<user>/<project>/tree/<branch>/latest`
+ * redirect to list of artifacts ([example](/api/v1/project/tknerr/linus-kitchen/tree/master/latest/artifacts)):
+  * `GET /api/v1/project/<user>/<project>/tree/<branch>/latest/artifacts`
+ * redirect to build artifact download ([example](/api/v1/project/tknerr/linus-kitchen/tree/master/latest/artifacts/test-report.html)):
+  * `GET /api/v1/project/<user>/<project>/tree/<branch>/latest/artifacts/<artifact>`
 
 For more details see [tknerr/circleci-redirector](https://github.com/tknerr/circleci-redirector)


### PR DESCRIPTION
This PR adds a route to catch all GET requests to `/api/v1/*` which do not match the other routes. This means that we are now extending the CircleCI REST API with additional endpoints and can act as a drop-in replacement (for GET requests only).

It also aligns the URL patterns with the existing ones from CircleCI REST API, adds a new endpoint to access test results for the latest build, some cleanup and README update.
